### PR TITLE
Have query return all values in db after watson values inserted

### DIFF
--- a/server/db/model.js
+++ b/server/db/model.js
@@ -19,17 +19,19 @@ module.exports = {
       // returns results in order of increasing distance from loc also return a
       // "distance" property that represents the entity's distance from the
       // midpoint
+      console.log('Input values to getByLocation in model.js: ', loc);
       return db
-      .select(db.raw(`*, (
-        3959 * acos(cos(radians(${loc.lat})) * cos(radians(lat)) * 
-        cos(radians(lng) - radians(${loc.lng})) + sin(radians(${loc.lat})) * 
-        sin(radians(lat)))
-        ) as distance`
-      ))
+      // .select(db.raw(`*, (
+      //   3959 * acos(cos(radians(${loc.lat})) * cos(radians(lat)) *
+      //   cos(radians(lng) - radians(${loc.lng})) + sin(radians(${loc.lat})) *
+      //   sin(radians(lat)))
+      //   ) as distance`
+      // ))
+      .select(db.raw('*'))
       .from('news')
-      .having('distance', '<', loc.rad)
-      .orderBy('distance', 'asc')
-      .limit(100)
+      // .having('distance', '<', loc.rad)
+      // .orderBy('distance', 'asc')
+      // .limit(100)
       .catch(err => console.log('Error getting by location', err));
     },
     add(data) {


### PR DESCRIPTION
This will temporarily make it so the query returns EVERYTHING in
the database.

Now we can play with the values and how they are represented on the
page as we work to building better queries, both to watson, and to
our own story cache.
